### PR TITLE
feat: 스켈레톤 이미지 적용, Glide 크기 조절 메모리 캐싱 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,4 +90,7 @@ dependencies {
     implementation(libs.room.runtime)
     ksp(libs.room.compiler)
     implementation(libs.room.ktx)
+
+    //shimmer
+    implementation(libs.shimmer)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,4 +93,5 @@ dependencies {
 
     //shimmer
     implementation(libs.shimmer)
+    implementation(libs.shimmer.recyclerview)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,5 +93,5 @@ dependencies {
 
     //shimmer
     implementation(libs.shimmer)
-    implementation(libs.shimmer.recyclerview)
+
 }

--- a/app/src/main/java/com/example/ishopping/data/source/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/ishopping/data/source/local/AppDatabase.kt
@@ -10,5 +10,4 @@ import com.example.ishopping.util.converters.ShoppingItemTypeConverter
 @TypeConverters(ShoppingItemTypeConverter::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun bookmarkItemDao(): ShoppingItemDao
-
 }

--- a/app/src/main/java/com/example/ishopping/ui/extensions/ShimmerFrameLayoutExtensions.kt
+++ b/app/src/main/java/com/example/ishopping/ui/extensions/ShimmerFrameLayoutExtensions.kt
@@ -1,0 +1,14 @@
+package com.example.ishopping.ui.extensions
+
+import android.util.Log
+import android.view.View
+import androidx.databinding.BindingAdapter
+import com.facebook.shimmer.ShimmerFrameLayout
+
+@BindingAdapter("shimmerVisibility")
+fun ShimmerFrameLayout.handleShimmerVisibility(isLoading: Boolean) {
+    Log.d("handleShimmerVisibility", "isLoading: $isLoading")
+    visibility = if (isLoading) View.VISIBLE else View.GONE
+    Log.d("handleShimmerVisibility", "visibility: $visibility")
+    if (isLoading) startShimmer() else stopShimmer()
+}

--- a/app/src/main/java/com/example/ishopping/ui/extensions/ShimmerFrameLayoutExtensions.kt
+++ b/app/src/main/java/com/example/ishopping/ui/extensions/ShimmerFrameLayoutExtensions.kt
@@ -1,14 +1,11 @@
 package com.example.ishopping.ui.extensions
 
-import android.util.Log
 import android.view.View
 import androidx.databinding.BindingAdapter
 import com.facebook.shimmer.ShimmerFrameLayout
 
 @BindingAdapter("shimmerVisibility")
 fun ShimmerFrameLayout.handleShimmerVisibility(isLoading: Boolean) {
-    Log.d("handleShimmerVisibility", "isLoading: $isLoading")
     visibility = if (isLoading) View.VISIBLE else View.GONE
-    Log.d("handleShimmerVisibility", "visibility: $visibility")
     if (isLoading) startShimmer() else stopShimmer()
 }

--- a/app/src/main/java/com/example/ishopping/ui/extensions/ViewExtensions.kt
+++ b/app/src/main/java/com/example/ishopping/ui/extensions/ViewExtensions.kt
@@ -1,0 +1,9 @@
+package com.example.ishopping.ui.extensions
+
+import android.view.View
+import androidx.databinding.BindingAdapter
+
+@BindingAdapter("inverseVisibility")
+fun View.setInverseVisibility(isLoading: Boolean) {
+    visibility = if (isLoading) View.GONE else View.VISIBLE
+}

--- a/app/src/main/java/com/example/ishopping/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/ishopping/ui/home/HomeFragment.kt
@@ -24,6 +24,7 @@ class HomeFragment : Fragment() {
     private val adapter = HomeShoppingItemAdapter(ShoppingItemComparator) { shoppingItem ->
         viewModel.onBookmarkButtonClick(shoppingItem)
     }
+    private val shimmerAdapter = ShimmerAdapter()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -46,8 +47,18 @@ class HomeFragment : Fragment() {
     }
 
     private fun setLayout() {
+        binding.rvShimmerList.adapter = shimmerAdapter
         binding.rvShoppingItemList.adapter = adapter
         viewModel.loadShoppingItems(getString(R.string.label_bag))
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.isLoading.collect { isLoading ->
+                    binding.isLoading = isLoading
+                }
+            }
+        }
+
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.items.collect { shoppingItems ->

--- a/app/src/main/java/com/example/ishopping/ui/home/HomeShoppingItemViewmodel.kt
+++ b/app/src/main/java/com/example/ishopping/ui/home/HomeShoppingItemViewmodel.kt
@@ -6,6 +6,7 @@ import com.example.ishopping.data.model.ShoppingItem
 import com.example.ishopping.data.source.HomeRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -15,6 +16,9 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeShoppingItemViewmodel @Inject constructor(private val repository: HomeRepository) :
     ViewModel() {
+
+    private val _isLoading = MutableStateFlow(true)
+    val isLoading = _isLoading.asStateFlow()
 
     private val _items = MutableStateFlow<List<ShoppingItem>>(emptyList())
     val items = _items.asStateFlow()
@@ -34,9 +38,11 @@ class HomeShoppingItemViewmodel @Inject constructor(private val repository: Home
     }
 
     fun loadShoppingItems(query: String) {
+        _isLoading.value = true
         viewModelScope.launch {
             val shoppingItems = repository.getShoppingItems(query)
             _items.value = shoppingItems
+            _isLoading.value = false
         }
     }
 
@@ -48,13 +54,13 @@ class HomeShoppingItemViewmodel @Inject constructor(private val repository: Home
         }
     }
 
-    fun addBookmark(shoppingItem: ShoppingItem) {
+    private fun addBookmark(shoppingItem: ShoppingItem) {
         viewModelScope.launch(Dispatchers.IO) {
             repository.insertBookmarkItem(shoppingItem.copy(isBookmarked = true))
         }
     }
 
-    fun removeBookmark(shoppingItem: ShoppingItem) {
+    private fun removeBookmark(shoppingItem: ShoppingItem) {
         viewModelScope.launch(Dispatchers.IO) {
             repository.deleteBookmarkItem(shoppingItem)
         }

--- a/app/src/main/java/com/example/ishopping/ui/home/HomeShoppingItemViewmodel.kt
+++ b/app/src/main/java/com/example/ishopping/ui/home/HomeShoppingItemViewmodel.kt
@@ -6,7 +6,6 @@ import com.example.ishopping.data.model.ShoppingItem
 import com.example.ishopping.data.source.HomeRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine

--- a/app/src/main/java/com/example/ishopping/ui/home/ShimmerAdapter.kt
+++ b/app/src/main/java/com/example/ishopping/ui/home/ShimmerAdapter.kt
@@ -1,0 +1,30 @@
+package com.example.ishopping.ui.home
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.ishopping.databinding.ItemShimmerShoppingItemBinding
+
+class ShimmerAdapter : RecyclerView.Adapter<ShimmerAdapter.ShimmerViewHolder>() {
+    private val itemCount = 4
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ShimmerViewHolder {
+        return ShimmerViewHolder(
+            ItemShimmerShoppingItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: ShimmerViewHolder, position: Int) {
+
+    }
+
+    override fun getItemCount(): Int = itemCount
+
+    class ShimmerViewHolder(
+        val binding: ItemShimmerShoppingItemBinding
+    ) : RecyclerView.ViewHolder(binding.root)
+}

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -5,6 +5,9 @@
 
     <data>
 
+        <variable
+            name="isLoading"
+            type="Boolean" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -63,9 +66,9 @@
             android:layout_width="0dp"
             android:layout_height="180dp"
             android:layout_marginTop="24dp"
-            android:src="@drawable/banner"
-            android:scaleType="centerCrop"
             android:adjustViewBounds="true"
+            android:scaleType="centerCrop"
+            android:src="@drawable/banner"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_home_special_offers"
@@ -89,6 +92,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="12dp"
             android:layout_marginEnd="16dp"
+            app:inverseVisibility="@{isLoading}"
             app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -96,5 +100,27 @@
             app:layout_constraintTop_toBottomOf="@id/tv_home_suggestion"
             app:spanCount="2"
             tools:listitem="@layout/item_search_shopping_item" />
+
+        <com.facebook.shimmer.ShimmerFrameLayout
+            android:id="@+id/shimmer_layout"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="12dp"
+            android:layout_marginEnd="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_home_suggestion"
+            app:shimmerVisibility="@{isLoading}">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_shimmer_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:spanCount="2"
+                tools:listitem="@layout/item_shimmer_shopping_item" />
+        </com.facebook.shimmer.ShimmerFrameLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_shimmer_shopping_item.xml
+++ b/app/src/main/res/layout/item_shimmer_shopping_item.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="12dp">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_shopping_item_image"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/greyscale_600"
+            android:contentDescription="@string/description_shimmer_shopping_item"
+            android:scaleType="centerCrop"
+            app:layout_constraintDimensionRatio="w, 1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:shapeAppearance="@style/ShoppingItemRoundedImage"
+            tools:background="@color/greyscale_600" />
+
+        <TextView
+            android:id="@+id/tv_shopping_item_title"
+            style="@style/AppTextH6.GreyScale900.Bold"
+            android:layout_width="200dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@color/greyscale_600"
+            android:ellipsize="end"
+            android:maxLines="1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_shopping_item_image" />
+
+        <TextView
+            android:id="@+id/tv_shopping_item_price"
+            style="@style/AppTextH6.GreyScale900.Bold"
+            android:layout_width="100dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="@color/greyscale_600"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_shopping_item_title" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,7 @@
     <string name="description_shopping_item">검색 상품</string>
     <string name="label_bag">가방</string>
     <string name="label_toolbar_like">My Wishlist</string>
+
+    <!--shimmer -->
+    <string name="description_shimmer_shopping_item">검색 상품 스켈레톤</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,6 @@ room = "2.6.1"
 
 # shimmer
 shimmer = "0.5.0"
-shimmer-recyclerview = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -67,7 +66,6 @@ room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 
 shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }
-shimmer-recyclerview = { module = "com.todkars:shimmer-recyclerview", version.ref = "shimmer-recyclerview" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ room = "2.6.1"
 
 # shimmer
 shimmer = "0.5.0"
+shimmer-recyclerview = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -66,7 +67,7 @@ room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 
 shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }
-
+shimmer-recyclerview = { module = "com.todkars:shimmer-recyclerview", version.ref = "shimmer-recyclerview" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,9 @@ paging = "3.3.5"
 # room
 room = "2.6.1"
 
+# shimmer
+shimmer = "0.5.0"
+
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 
@@ -61,6 +64,9 @@ paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "pag
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
+
+shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }


### PR DESCRIPTION
👩‍🌾 진행한 작업
- Shimmer를 활용한 스켈레톤 이미지 적용
- Glide를 활용한 크기 조절 메모리 캐싱

📷 작업 결과

[Screen_recording_20250210_162415.webm](https://github.com/user-attachments/assets/fc8cf17a-b69c-419b-82a1-c4da3dcbc605)


🗣️ 특이사항
- 네트워크 로딩이 빨라서 스켈레톤 화면이 거의 출력되지 않음. (영상은 명확한 확인을 위해 1초의 dealy를 적용)
- 따라서 기술적 경험으로 생각하고 home 화면에만 적용
- facebook-shimmer를 사용함. shimmer-recyclerview를 사용하려 했으나 작동을 안함 . .
- 별도의 처리를 안해주어도 Glide 내부적으로 리사이클러뷰의 ImageView의 크기에 맞게 조절하여 캐싱하고 있었음.
- 내부 코드 분석하여 블로그 글 작성 예정
closed #13 